### PR TITLE
[SMR-1914] data length must be greater than 32

### DIFF
--- a/src/child/ChildERC20Bridge.sol
+++ b/src/child/ChildERC20Bridge.sol
@@ -115,7 +115,7 @@ contract ChildERC20Bridge is
         if (data.length <= 32) {
             // Data must always be greater than 32.
             // 32 bytes for the signature, and at least some information for the payload
-            revert DataTooShort();
+            revert InvalidData("Data too short");
         }
 
         if (bytes32(data[:32]) == MAP_TOKEN_SIG) {
@@ -123,7 +123,7 @@ contract ChildERC20Bridge is
         } else if (bytes32(data[:32]) == DEPOSIT_SIG) {
             _deposit(data[32:]);
         } else {
-            revert InvalidData();
+            revert InvalidData("Unsupported action signature");
         }
     }
 

--- a/src/interfaces/child/IChildERC20Bridge.sol
+++ b/src/interfaces/child/IChildERC20Bridge.sol
@@ -72,10 +72,8 @@ interface IChildERC20BridgeErrors {
     error AlreadyMapped();
     /// @notice Error when a message is given to the bridge from an address not the designated bridge adaptor.
     error NotBridgeAdaptor();
-    /// @notice Error when the message's payload is too short.
-    error DataTooShort();
     /// @notice Error when the message's payload is not valid.
-    error InvalidData();
+    error InvalidData(string reason);
     /// @notice Error when the message's source chain is not valid.
     error InvalidSourceChain();
     /// @notice Error when the source chain's message sender is not a recognised address.

--- a/src/interfaces/root/IRootERC20Bridge.sol
+++ b/src/interfaces/root/IRootERC20Bridge.sol
@@ -105,10 +105,8 @@ interface IRootERC20BridgeErrors {
     error BalanceInvariantCheckFailed(uint256 actualBalance, uint256 expectedBalance);
     /// @notice Error when the given child chain bridge adaptor is invalid.
     error InvalidChildERC20BridgeAdaptor();
-    /// @notice Error when the message's payload is too short.
-    error DataTooShort();
     /// @notice Error when a message received has invalid data.
-    error InvalidData();
+    error InvalidData(string reason);
     /// @notice Error when a message received has invalid source address.
     error InvalidSourceAddress();
     /// @notice Error when a message received has invalid source chain.

--- a/src/root/RootERC20Bridge.sol
+++ b/src/root/RootERC20Bridge.sol
@@ -167,13 +167,13 @@ contract RootERC20Bridge is
         if (data.length <= 32) {
             // Data must always be greater than 32.
             // 32 bytes for the signature, and at least some information for the payload
-            revert DataTooShort();
+            revert InvalidData("Data too short");
         }
 
         if (bytes32(data[:32]) == WITHDRAW_SIG) {
             _withdraw(data[32:]);
         } else {
-            revert InvalidData();
+            revert InvalidData("Unsupported action signature");
         }
     }
 

--- a/test/integration/child/ChildAxelarBridge.t.sol
+++ b/test/integration/child/ChildAxelarBridge.t.sol
@@ -83,7 +83,7 @@ contract ChildERC20BridgeIntegrationTest is Test, IChildERC20BridgeEvents, IChil
         bytes32 commandId = bytes32("testCommandId");
         bytes memory payload = abi.encode("invalid payload");
 
-        vm.expectRevert(InvalidData.selector);
+        vm.expectRevert(abi.encodeWithSelector(InvalidData.selector, "Unsupported action signature"));
         childAxelarBridgeAdaptor.execute(commandId, ROOT_CHAIN_NAME, ROOT_ADAPTOR_ADDRESS, payload);
     }
 
@@ -109,7 +109,7 @@ contract ChildERC20BridgeIntegrationTest is Test, IChildERC20BridgeEvents, IChil
         bytes32 commandId = bytes32("testCommandId");
         bytes memory payload = "";
 
-        vm.expectRevert(DataTooShort.selector);
+        vm.expectRevert(abi.encodeWithSelector(InvalidData.selector, "Data too short"));
         childAxelarBridgeAdaptor.execute(commandId, ROOT_CHAIN_NAME, ROOT_ADAPTOR_ADDRESS, payload);
     }
 

--- a/test/integration/root/withdrawals.t.sol/RootERC20BridgeWithdraw.t.sol
+++ b/test/integration/root/withdrawals.t.sol/RootERC20BridgeWithdraw.t.sol
@@ -87,7 +87,7 @@ contract RootERC20BridgeWithdrawIntegrationTest is
         bytes32 commandId = bytes32("testCommandId");
         string memory sourceAddress = rootBridge.childBridgeAdaptor();
 
-        vm.expectRevert(DataTooShort.selector);
+        vm.expectRevert(abi.encodeWithSelector(InvalidData.selector, "Data too short"));
         axelarAdaptor.execute(commandId, CHILD_CHAIN_NAME, sourceAddress, data);
     }
 
@@ -97,7 +97,7 @@ contract RootERC20BridgeWithdrawIntegrationTest is
         bytes32 commandId = bytes32("testCommandId");
         string memory sourceAddress = rootBridge.childBridgeAdaptor();
 
-        vm.expectRevert(InvalidData.selector);
+        vm.expectRevert(abi.encodeWithSelector(InvalidData.selector, "Unsupported action signature"));
         axelarAdaptor.execute(commandId, CHILD_CHAIN_NAME, sourceAddress, data);
     }
 

--- a/test/unit/child/ChildERC20Bridge.t.sol
+++ b/test/unit/child/ChildERC20Bridge.t.sol
@@ -168,7 +168,7 @@ contract ChildERC20BridgeUnitTest is Test, IChildERC20BridgeEvents, IChildERC20B
 
     function test_RevertIf_onMessageReceiveCalledWithDataLengthZero() public {
         bytes memory data = "";
-        vm.expectRevert(DataTooShort.selector);
+        vm.expectRevert(abi.encodeWithSelector(InvalidData.selector, "Data too short"));
         childBridge.onMessageReceive(ROOT_CHAIN_NAME, ROOT_BRIDGE_ADAPTOR, data);
     }
 
@@ -176,7 +176,7 @@ contract ChildERC20BridgeUnitTest is Test, IChildERC20BridgeEvents, IChildERC20B
         bytes memory data =
             abi.encode("FAKEDATA", address(rootToken), rootToken.name(), rootToken.symbol(), rootToken.decimals());
 
-        vm.expectRevert(InvalidData.selector);
+        vm.expectRevert(abi.encodeWithSelector(InvalidData.selector, "Unsupported action signature"));
         childBridge.onMessageReceive(ROOT_CHAIN_NAME, ROOT_BRIDGE_ADAPTOR, data);
     }
 

--- a/test/unit/root/withdrawals/RootERC20BridgeWithdraw.t.sol
+++ b/test/unit/root/withdrawals/RootERC20BridgeWithdraw.t.sol
@@ -84,14 +84,16 @@ contract RootERC20BridgeWithdrawUnitTest is Test, IRootERC20BridgeEvents, IRootE
         bytes memory data;
 
         vm.prank(address(mockAxelarAdaptor));
-        vm.expectRevert(DataTooShort.selector);
+        vm.expectRevert(abi.encodeWithSelector(InvalidData.selector, "Data too short"));
+
         rootBridge.onMessageReceive(CHILD_CHAIN_NAME, CHILD_BRIDGE_ADAPTOR_STRING, data);
     }
 
     function test_RevertsIf_OnMessageReceiveWithInvalidSignature() public {
         bytes memory data = abi.encode(keccak256("RANDOM"), IMX_TOKEN, address(this), address(this), withdrawAmount);
+
         vm.prank(address(mockAxelarAdaptor));
-        vm.expectRevert(InvalidData.selector);
+        vm.expectRevert(abi.encodeWithSelector(InvalidData.selector, "Unsupported action signature"));
         rootBridge.onMessageReceive(CHILD_CHAIN_NAME, CHILD_BRIDGE_ADAPTOR_STRING, data);
     }
 


### PR DESCRIPTION
We know that data currently has to be greater than 32.

It is possible in the future we might have a message type that requires no further data. There currently are no plans for that, but in that case we would loosen this requirement a bit.