### PR TITLE
update solc version to 0.8.19

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -2,5 +2,6 @@
 src = "src"
 out = "out"
 libs = ["lib"]
+solc-version = "0.8.19"
 
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options

--- a/script/DeployChildContracts.s.sol
+++ b/script/DeployChildContracts.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity ^0.8.21;
+pragma solidity 0.8.19;
 
 import {Script, console2} from "forge-std/Script.sol";
 

--- a/script/DeployRootContracts.s.sol
+++ b/script/DeployRootContracts.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity ^0.8.21;
+pragma solidity 0.8.19;
 
 import {Script, console2} from "forge-std/Script.sol";
 

--- a/script/InitializeChildContracts.s.sol
+++ b/script/InitializeChildContracts.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity ^0.8.21;
+pragma solidity 0.8.19;
 
 import {Script, console2} from "forge-std/Script.sol";
 

--- a/script/InitializeRootContracts.s.sol
+++ b/script/InitializeRootContracts.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity ^0.8.21;
+pragma solidity 0.8.19;
 
 import {Script, console2} from "forge-std/Script.sol";
 

--- a/script/Utils.sol
+++ b/script/Utils.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity ^0.8.21;
+pragma solidity 0.8.19;
 
 import {AddressToString} from "@axelar-gmp-sdk-solidity/contracts/libs/AddressString.sol";
 

--- a/src/child/ChildAxelarBridgeAdaptor.sol
+++ b/src/child/ChildAxelarBridgeAdaptor.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity ^0.8.21;
+pragma solidity 0.8.19;
 
 import {AxelarExecutable} from "@axelar-gmp-sdk-solidity/contracts/executable/AxelarExecutable.sol";
 import {IAxelarGasService} from "@axelar-cgp-solidity/contracts/interfaces/IAxelarGasService.sol";

--- a/src/child/ChildERC20.sol
+++ b/src/child/ChildERC20.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache 2.0
 // Adapted from OpenZeppelin Contracts (last updated v4.8.0) (token/ERC20/ERC20.sol)
-pragma solidity ^0.8.21;
+pragma solidity 0.8.19;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
 import "../lib/EIP712MetaTransaction.sol";

--- a/src/child/ChildERC20Bridge.sol
+++ b/src/child/ChildERC20Bridge.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity ^0.8.21;
+pragma solidity 0.8.19;
 
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";

--- a/src/child/WIMX.sol
+++ b/src/child/WIMX.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity ^0.8.21;
+pragma solidity 0.8.19;
 
 import {IWIMX} from "../interfaces/child/IWIMX.sol";
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";

--- a/src/interfaces/child/IChildAxelarBridgeAdaptor.sol
+++ b/src/interfaces/child/IChildAxelarBridgeAdaptor.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity ^0.8.21;
+pragma solidity 0.8.19;
 
 interface IChildAxelarBridgeAdaptorErrors {
     /// @notice Error when a zero address is given when not valid.

--- a/src/interfaces/child/IChildERC20.sol
+++ b/src/interfaces/child/IChildERC20.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache 2.0
 // OpenZeppelin Contracts (last updated v4.8.0) (token/ERC20/ERC20.sol)
 
-pragma solidity ^0.8.21;
+pragma solidity 0.8.19;
 
 import {IERC20MetadataUpgradeable} from
     "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/IERC20MetadataUpgradeable.sol";

--- a/src/interfaces/child/IChildERC20Bridge.sol
+++ b/src/interfaces/child/IChildERC20Bridge.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity ^0.8.21;
+pragma solidity 0.8.19;
 
 import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 

--- a/src/interfaces/child/IChildERC20BridgeAdaptor.sol
+++ b/src/interfaces/child/IChildERC20BridgeAdaptor.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity ^0.8.21;
+pragma solidity 0.8.19;
 
 interface IChildERC20BridgeAdaptor {
     /**

--- a/src/interfaces/child/IWIMX.sol
+++ b/src/interfaces/child/IWIMX.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity ^0.8.21;
+pragma solidity 0.8.19;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 

--- a/src/interfaces/root/IRootAxelarBridgeAdaptor.sol
+++ b/src/interfaces/root/IRootAxelarBridgeAdaptor.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity ^0.8.21;
+pragma solidity 0.8.19;
 
 interface IRootAxelarBridgeAdaptorErrors {
     /// @notice Error when a zero address is given when not valid.

--- a/src/interfaces/root/IRootERC20Bridge.sol
+++ b/src/interfaces/root/IRootERC20Bridge.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity ^0.8.21;
+pragma solidity 0.8.19;
 
 import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 

--- a/src/interfaces/root/IRootERC20BridgeAdaptor.sol
+++ b/src/interfaces/root/IRootERC20BridgeAdaptor.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity ^0.8.21;
+pragma solidity 0.8.19;
 
 // TODO: This is likely able to become a generic bridge adaptor, not just for ERC20 tokens.
 interface IRootERC20BridgeAdaptor {

--- a/src/interfaces/root/IWETH.sol
+++ b/src/interfaces/root/IWETH.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity ^0.8.21;
+pragma solidity 0.8.19;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 

--- a/src/lib/EIP712MetaTransaction.sol
+++ b/src/lib/EIP712MetaTransaction.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: Apache 2.0
-pragma solidity ^0.8.21;
+pragma solidity 0.8.19;
 
 import "./EIP712Upgradeable.sol";
 

--- a/src/lib/EIP712Upgradeable.sol
+++ b/src/lib/EIP712Upgradeable.sol
@@ -2,7 +2,7 @@
 // slither-disable-start naming-convention
 // Adapted from OpenZeppelin Contracts (last updated v4.8.0) (utils/cryptography/EIP712.sol)
 
-pragma solidity ^0.8.21;
+pragma solidity 0.8.19;
 
 import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 

--- a/src/root/RootAxelarBridgeAdaptor.sol
+++ b/src/root/RootAxelarBridgeAdaptor.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity ^0.8.21;
+pragma solidity 0.8.19;
 
 import {AxelarExecutable} from "@axelar-gmp-sdk-solidity/contracts/executable/AxelarExecutable.sol";
 import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";

--- a/src/root/RootERC20Bridge.sol
+++ b/src/root/RootERC20Bridge.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity ^0.8.21;
+pragma solidity 0.8.19;
 
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";

--- a/src/test/child/ChildERC20FailOnBurn.sol
+++ b/src/test/child/ChildERC20FailOnBurn.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache 2.0
 // Adapted from OpenZeppelin Contracts (last updated v4.8.0) (token/ERC20/ERC20.sol)
-pragma solidity ^0.8.21;
+pragma solidity 0.8.19;
 
 import "../../child/ChildERC20.sol";
 

--- a/src/test/child/MockChildAxelarGasService.sol
+++ b/src/test/child/MockChildAxelarGasService.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity ^0.8.21;
+pragma solidity 0.8.19;
 
 contract MockChildAxelarGasService {
     function payNativeGasForContractCall(

--- a/src/test/child/MockChildAxelarGateway.sol
+++ b/src/test/child/MockChildAxelarGateway.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity ^0.8.21;
+pragma solidity 0.8.19;
 
 contract MockChildAxelarGateway {
     function validateContractCall(bytes32, string calldata, string calldata, bytes32) external pure returns (bool) {

--- a/src/test/child/MockChildERC20Bridge.sol
+++ b/src/test/child/MockChildERC20Bridge.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity ^0.8.21;
+pragma solidity 0.8.19;
 
 contract MockChildERC20Bridge {
     function onMessageReceive(string calldata, string calldata, bytes calldata) external {}

--- a/src/test/root/MockAdaptor.sol
+++ b/src/test/root/MockAdaptor.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity ^0.8.21;
+pragma solidity 0.8.19;
 
 // @dev A contract for ensuring the Axelar Bridge Adaptor is called correctly during unit tests.
 contract MockAdaptor {

--- a/src/test/root/MockAxelarGasService.sol
+++ b/src/test/root/MockAxelarGasService.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity ^0.8.21;
+pragma solidity 0.8.19;
 
 // @dev A contract for ensuring the Axelar gas service is called correctly during unit tests.
 contract MockAxelarGasService {

--- a/src/test/root/MockAxelarGateway.sol
+++ b/src/test/root/MockAxelarGateway.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity ^0.8.21;
+pragma solidity 0.8.19;
 
 // @dev A contract for ensuring the Axelar Gateway is called correctly during unit tests.
 contract MockAxelarGateway {

--- a/src/test/root/StubRootBridge.sol
+++ b/src/test/root/StubRootBridge.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity ^0.8.21;
+pragma solidity 0.8.19;
 
 import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 

--- a/src/test/root/WETH.sol
+++ b/src/test/root/WETH.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity ^0.8.21;
+pragma solidity 0.8.19;
 
 import {IWETH} from "../../interfaces/root/IWETH.sol";
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";

--- a/test/integration/child/ChildAxelarBridge.t.sol
+++ b/test/integration/child/ChildAxelarBridge.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity ^0.8.21;
+pragma solidity 0.8.19;
 
 import {Test, console2} from "forge-std/Test.sol";
 import {Clones} from "@openzeppelin/contracts/proxy/Clones.sol";

--- a/test/integration/child/withdrawals/ChildAxelarBridgeWithdraw.t.sol
+++ b/test/integration/child/withdrawals/ChildAxelarBridgeWithdraw.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity ^0.8.21;
+pragma solidity 0.8.19;
 
 import {Test, console2} from "forge-std/Test.sol";
 import {ERC20PresetMinterPauser} from "@openzeppelin/contracts/token/ERC20/presets/ERC20PresetMinterPauser.sol";

--- a/test/integration/child/withdrawals/ChildAxelarBridgeWithdrawIMX.t.sol
+++ b/test/integration/child/withdrawals/ChildAxelarBridgeWithdrawIMX.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity ^0.8.21;
+pragma solidity 0.8.19;
 
 import {Test, console2} from "forge-std/Test.sol";
 import {ERC20PresetMinterPauser} from "@openzeppelin/contracts/token/ERC20/presets/ERC20PresetMinterPauser.sol";

--- a/test/integration/child/withdrawals/ChildAxelarBridgeWithdrawTo.t.sol
+++ b/test/integration/child/withdrawals/ChildAxelarBridgeWithdrawTo.t.sol
@@ -1,1 +1,1 @@
-
+pragma solidity 0.8.19;

--- a/test/integration/child/withdrawals/ChildAxelarBridgeWithdrawToIMX.t.sol
+++ b/test/integration/child/withdrawals/ChildAxelarBridgeWithdrawToIMX.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity ^0.8.21;
+pragma solidity 0.8.19;
 
 import {Test, console2} from "forge-std/Test.sol";
 import {ERC20PresetMinterPauser} from "@openzeppelin/contracts/token/ERC20/presets/ERC20PresetMinterPauser.sol";

--- a/test/integration/root/RootERC20Bridge.t.sol
+++ b/test/integration/root/RootERC20Bridge.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity ^0.8.21;
+pragma solidity 0.8.19;
 
 import {Test, console2} from "forge-std/Test.sol";
 import {ERC20PresetMinterPauser} from "@openzeppelin/contracts/token/ERC20/presets/ERC20PresetMinterPauser.sol";

--- a/test/integration/root/withdrawals.t.sol/RootERC20BridgeWithdraw.t.sol
+++ b/test/integration/root/withdrawals.t.sol/RootERC20BridgeWithdraw.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity ^0.8.21;
+pragma solidity 0.8.19;
 
 import {Test, console2} from "forge-std/Test.sol";
 import {ERC20PresetMinterPauser} from "@openzeppelin/contracts/token/ERC20/presets/ERC20PresetMinterPauser.sol";

--- a/test/unit/child/ChildAxelarBridgeAdaptor.t.sol
+++ b/test/unit/child/ChildAxelarBridgeAdaptor.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity ^0.8.21;
+pragma solidity 0.8.19;
 
 import {Test, console2} from "forge-std/Test.sol";
 import {Clones} from "@openzeppelin/contracts/proxy/Clones.sol";

--- a/test/unit/child/ChildERC20Bridge.t.sol
+++ b/test/unit/child/ChildERC20Bridge.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity ^0.8.21;
+pragma solidity 0.8.19;
 
 import {Test, console2} from "forge-std/Test.sol";
 import {ERC20PresetMinterPauser} from "@openzeppelin/contracts/token/ERC20/presets/ERC20PresetMinterPauser.sol";

--- a/test/unit/child/WIMX.t.sol
+++ b/test/unit/child/WIMX.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity ^0.8.21;
+pragma solidity 0.8.19;
 
 import {Test} from "forge-std/Test.sol";
 import {WIMX} from "../../../src/child/WIMX.sol";

--- a/test/unit/child/withdrawals/ChildERC20BridgeWithdraw.t.sol
+++ b/test/unit/child/withdrawals/ChildERC20BridgeWithdraw.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity ^0.8.21;
+pragma solidity 0.8.19;
 
 import {Test, console2} from "forge-std/Test.sol";
 import {ERC20PresetMinterPauser} from "@openzeppelin/contracts/token/ERC20/presets/ERC20PresetMinterPauser.sol";

--- a/test/unit/child/withdrawals/ChildERC20BridgeWithdrawIMX.t.sol
+++ b/test/unit/child/withdrawals/ChildERC20BridgeWithdrawIMX.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity ^0.8.21;
+pragma solidity 0.8.19;
 
 import {Test, console2} from "forge-std/Test.sol";
 import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";

--- a/test/unit/child/withdrawals/ChildERC20BridgeWithdrawTo.t.sol
+++ b/test/unit/child/withdrawals/ChildERC20BridgeWithdrawTo.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity ^0.8.21;
+pragma solidity 0.8.19;
 
 import {Test, console2} from "forge-std/Test.sol";
 import {ERC20PresetMinterPauser} from "@openzeppelin/contracts/token/ERC20/presets/ERC20PresetMinterPauser.sol";

--- a/test/unit/child/withdrawals/ChildERC20BridgeWithdrawToIMX.t.sol
+++ b/test/unit/child/withdrawals/ChildERC20BridgeWithdrawToIMX.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity ^0.8.21;
+pragma solidity 0.8.19;
 
 import {Test, console2} from "forge-std/Test.sol";
 import {ERC20PresetMinterPauser} from "@openzeppelin/contracts/token/ERC20/presets/ERC20PresetMinterPauser.sol";

--- a/test/unit/root/RootAxelarBridgeAdaptor.t.sol
+++ b/test/unit/root/RootAxelarBridgeAdaptor.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity ^0.8.21;
+pragma solidity 0.8.19;
 
 import {Test, console2} from "forge-std/Test.sol";
 import {ERC20PresetMinterPauser} from "@openzeppelin/contracts/token/ERC20/presets/ERC20PresetMinterPauser.sol";

--- a/test/unit/root/RootERC20Bridge.t.sol
+++ b/test/unit/root/RootERC20Bridge.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity ^0.8.21;
+pragma solidity 0.8.19;
 
 import {Test, console2} from "forge-std/Test.sol";
 import {ERC20PresetMinterPauser} from "@openzeppelin/contracts/token/ERC20/presets/ERC20PresetMinterPauser.sol";

--- a/test/unit/root/withdrawals/RootAxelarBridgeAdaptorWithdraw.t.sol
+++ b/test/unit/root/withdrawals/RootAxelarBridgeAdaptorWithdraw.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity ^0.8.21;
+pragma solidity 0.8.19;
 
 import {Test, console2} from "forge-std/Test.sol";
 import {ERC20PresetMinterPauser} from "@openzeppelin/contracts/token/ERC20/presets/ERC20PresetMinterPauser.sol";

--- a/test/unit/root/withdrawals/RootERC20BridgeWithdraw.t.sol
+++ b/test/unit/root/withdrawals/RootERC20BridgeWithdraw.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity ^0.8.21;
+pragma solidity 0.8.19;
 
 import {Test, console2} from "forge-std/Test.sol";
 import {ERC20PresetMinterPauser} from "@openzeppelin/contracts/token/ERC20/presets/ERC20PresetMinterPauser.sol";

--- a/test/utils.t.sol
+++ b/test/utils.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity ^0.8.21;
+pragma solidity 0.8.19;
 
 import {Test, console2} from "forge-std/Test.sol";
 import {ERC20PresetMinterPauser} from "@openzeppelin/contracts/token/ERC20/presets/ERC20PresetMinterPauser.sol";


### PR DESCRIPTION
# update solc version to 0.8.19
To support our Immutable zkEVM, a pre-Shanghai Geth fork with no support for PUSH0 opcode.