### PR TITLE
Add integration test for withdrawTo

### DIFF
--- a/test/integration/child/withdrawals/ChildAxelarBridgeWithdrawTo.t.sol
+++ b/test/integration/child/withdrawals/ChildAxelarBridgeWithdrawTo.t.sol
@@ -26,15 +26,14 @@ contract ChildERC20BridgeWithdrawToIntegrationTest is
     ChildERC20Bridge public childBridge;
     ChildAxelarBridgeAdaptor public axelarAdaptor;
     address public rootToken;
-    MockAxelarGasService public axelarGasService;
+    MockAxelarGasService public mockAxelarGasService;
     MockAxelarGateway public mockAxelarGateway;
 
     address receiver = address(0xabcd);
 
     function setUp() public {
-        address rootImxToken;
         ChildERC20 childTokenTemplate;
-        (childBridge, axelarAdaptor, rootToken, rootImxToken, childTokenTemplate, axelarGasService, mockAxelarGateway) =
+        (childBridge, axelarAdaptor, rootToken,, childTokenTemplate, mockAxelarGasService, mockAxelarGateway) =
             childIntegrationSetup();
     }
 
@@ -79,10 +78,10 @@ contract ChildERC20BridgeWithdrawToIntegrationTest is
 
         bytes memory predictedPayload = abi.encode(WITHDRAW_SIG, rootToken, address(this), receiver, withdrawAmount);
         vm.expectCall(
-            address(axelarGasService),
+            address(mockAxelarGasService),
             withdrawFee,
             abi.encodeWithSelector(
-                axelarGasService.payNativeGasForContractCall.selector,
+                mockAxelarGasService.payNativeGasForContractCall.selector,
                 address(axelarAdaptor),
                 childBridge.rootChain(),
                 childBridge.rootERC20BridgeAdaptor(),
@@ -108,12 +107,12 @@ contract ChildERC20BridgeWithdrawToIntegrationTest is
         ChildERC20 childToken = ChildERC20(childBridge.rootTokenToChildToken(rootToken));
 
         uint256 preBal = childToken.balanceOf(address(this));
-        uint256 preGasBal = address(axelarGasService).balance;
+        uint256 preGasBal = address(mockAxelarGasService).balance;
 
         childBridge.withdrawTo{value: withdrawFee}(childToken, receiver, withdrawAmount);
 
         uint256 postBal = childToken.balanceOf(address(this));
-        uint256 postGasBal = address(axelarGasService).balance;
+        uint256 postGasBal = address(mockAxelarGasService).balance;
 
         assertEq(postBal, preBal - withdrawAmount, "Balance not reduced");
         assertEq(postGasBal, preGasBal + withdrawFee, "Gas not transferred");


### PR DESCRIPTION
This PR addresses [SMR-1959.](https://immutable.atlassian.net/browse/SMR-1959?atlOrigin=eyJpIjoiM2Q4OWU2NjBhMDE2NDBkY2I5YmM3NmQ0ODhiNmJmMGUiLCJwIjoiaiJ9) It adds integration tests for the `ChildERC20Bridge.withdrawTo()` function, and makes minor improvements to the existing integration tests for the `ChildERC20Bridge.withdraw()` function. 