### PR TITLE
comments updated as per feedback

### DIFF
--- a/src/child/ChildERC20.sol
+++ b/src/child/ChildERC20.sol
@@ -12,9 +12,9 @@ import "../interfaces/child/IChildERC20.sol";
  *   @author Polygon Technology (@QEDK)
  *   @notice Child token template for ChildERC20 predicate deployments
  *   @dev All child tokens are clones of this contract. Burning and minting is controlled by the ChildERC20Bridge.
- *   
+ *
  *   @dev Upgradability:
- *        This contract is deployed using cloneDeterministic. It is then initialized using an initialize function. 
+ *        This contract is deployed using cloneDeterministic. It is then initialized using an initialize function.
  *        However, the contract is accessed directly, and not via a transparent upgrade proxy. As such, this contract is not upgradeable.
  *
  *   @dev Cloning and Initialization:


### PR DESCRIPTION
resolves

ChildERC20: Revise documentation to indicate the bridge controls minting and burning: "@ dev All child tokens are clones of this contract. Burning and minting is controlled by respective predicates only."

ChildERC20: Add some documentation explaining why the contract is upgradeable and how the system of cloning, and then initializing works.