### PR TITLE
Add create2 contract deployer with access control

### DIFF
--- a/src/deploy/OwnableCreate2Deployer.sol
+++ b/src/deploy/OwnableCreate2Deployer.sol
@@ -11,14 +11,15 @@ import {Create2} from "@axelar-gmp-sdk-solidity/contracts/deploy/Create2.sol";
  * @notice Deploys and optionally initializes contracts using the `CREATE2` opcode.
  * @dev This contract extends the {Deployer} contract from the Axelar SDK, by adding basic access control to the deployment functions.
  *      The contract has an owner, which is the only entity that can deploy new contracts.
- *      The owner is initially set to the deployer of this contract and can be changed using {transferOwnership}.
  *
  * @dev The contract deploys a contract with the same bytecode, salt, and sender(owner) to the same address.
  *      Attempting to deploy a contract with the same bytecode, salt, and sender(owner) will revert.
  *      The address where the contract will be deployed can be found using {deployedAddress}.
  */
 contract OwnableCreate2Deployer is Ownable, Create2, Deployer {
-    constructor() Ownable() {}
+    constructor(address owner) Ownable() {
+        transferOwnership(owner);
+    }
 
     /**
      * @dev Deploys a contract using the `CREATE2` opcode.


### PR DESCRIPTION
This PR adds a create2 contract deployer and initialiser, with basic access controls. It addresses [SMR-2104](https://immutable.atlassian.net/browse/SMR-2104?atlOrigin=eyJpIjoiMDZjZDA3Mzg4MmJhNDg2Y2FiZjJkMzZkNDJmZDA2NjAiLCJwIjoiaiJ9)

[SMR-2104]: https://immutable.atlassian.net/browse/SMR-2104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ