### PR TITLE
update private function transferTokensAndEmitEvent  to have underscore

### DIFF
--- a/src/child/ChildERC20Bridge.sol
+++ b/src/child/ChildERC20Bridge.sol
@@ -459,10 +459,10 @@ contract ChildERC20Bridge is
             revert ZeroAddress();
         }
 
-        transferTokensAndEmitEvent(rootToken, rootTokenToChildToken[rootToken], sender, receiver, amount);
+        _transferTokensAndEmitEvent(rootToken, rootTokenToChildToken[rootToken], sender, receiver, amount);
     }
 
-    function transferTokensAndEmitEvent(
+    function _transferTokensAndEmitEvent(
         address rootToken,
         address childToken,
         address sender,


### PR DESCRIPTION
fixes: Apply a consistent naming convention for function names by renaming the transferTokensAndEmitEvent function of the ChildERC20Bridge contract.