### PR TITLE
added role to role function names

### DIFF
--- a/src/common/AdaptorRoles.sol
+++ b/src/common/AdaptorRoles.sol
@@ -24,14 +24,14 @@ abstract contract AdaptorRoles is AccessControlUpgradeable {
     /**
      * @notice Function to grant bridge manager role to an address
      */
-    function grantBridgeManager(address account) external onlyRole(DEFAULT_ADMIN_ROLE) {
+    function grantBridgeManagerRole(address account) external onlyRole(DEFAULT_ADMIN_ROLE) {
         grantRole(BRIDGE_MANAGER_ROLE, account);
     }
 
     /**
      * @notice Function to grant gas service manager role to an address
      */
-    function grantGasServiceManager(address account) external onlyRole(DEFAULT_ADMIN_ROLE) {
+    function grantGasServiceManagerRole(address account) external onlyRole(DEFAULT_ADMIN_ROLE) {
         grantRole(GAS_SERVICE_MANAGER_ROLE, account);
     }
 

--- a/test/unit/common/AdaptorRoles.t.sol
+++ b/test/unit/common/AdaptorRoles.t.sol
@@ -21,8 +21,8 @@ contract Setup is Test {
 contract AdaptorRoles is Setup {
     function grantRoles() internal {
         vm.startPrank(admin);
-        mockAdaptorRoles.grantBridgeManager(bridgeManager);
-        mockAdaptorRoles.grantGasServiceManager(gasServiceManager);
+        mockAdaptorRoles.grantBridgeManagerRole(bridgeManager);
+        mockAdaptorRoles.grantGasServiceManagerRole(gasServiceManager);
         mockAdaptorRoles.grantTargetManagerRole(targetManager);
         vm.stopPrank();
     }


### PR DESCRIPTION
fixes: Standardize the naming convention for functions granting and revoking roles in AdaptorRoles contract. Some of the functions are lacking the Role suffix.