### PR TITLE
renamed _roles to unique name spaces

### DIFF
--- a/src/child/ChildAxelarBridgeAdaptor.sol
+++ b/src/child/ChildAxelarBridgeAdaptor.sol
@@ -53,25 +53,23 @@ contract ChildAxelarBridgeAdaptor is
 
     /**
      * @notice Initialization function for ChildAxelarBridgeAdaptor.
-     * @param _childAxelarAdapterRoles Struct containing addresses of roles.
+     * @param _adaptorRoles Struct containing addresses of roles.
      * @param _childBridge Address of child bridge contract.
      * @param _rootChainId Axelar's string ID for the root chain.
      * @param _rootBridgeAdaptor Address of the bridge adaptor on the root chain.
      * @param _gasService Address of Axelar Gas Service contract.
      */
     function initialize(
-        InitializationRoles memory _childAxelarAdapterRoles,
+        InitializationRoles memory _adaptorRoles,
         address _childBridge,
         string memory _rootChainId,
         string memory _rootBridgeAdaptor,
         address _gasService
     ) external initializer {
         if (
-            _childBridge == address(0) || _gasService == address(0)
-                || _childAxelarAdapterRoles.defaultAdmin == address(0)
-                || _childAxelarAdapterRoles.bridgeManager == address(0)
-                || _childAxelarAdapterRoles.gasServiceManager == address(0)
-                || _childAxelarAdapterRoles.targetManager == address(0)
+            _childBridge == address(0) || _gasService == address(0) || _adaptorRoles.defaultAdmin == address(0)
+                || _adaptorRoles.bridgeManager == address(0) || _adaptorRoles.gasServiceManager == address(0)
+                || _adaptorRoles.targetManager == address(0)
         ) {
             revert ZeroAddress();
         }
@@ -85,10 +83,10 @@ contract ChildAxelarBridgeAdaptor is
         }
         __AccessControl_init();
 
-        _grantRole(DEFAULT_ADMIN_ROLE, _childAxelarAdapterRoles.defaultAdmin);
-        _grantRole(BRIDGE_MANAGER_ROLE, _childAxelarAdapterRoles.bridgeManager);
-        _grantRole(GAS_SERVICE_MANAGER_ROLE, _childAxelarAdapterRoles.gasServiceManager);
-        _grantRole(TARGET_MANAGER_ROLE, _childAxelarAdapterRoles.targetManager);
+        _grantRole(DEFAULT_ADMIN_ROLE, _adaptorRoles.defaultAdmin);
+        _grantRole(BRIDGE_MANAGER_ROLE, _adaptorRoles.bridgeManager);
+        _grantRole(GAS_SERVICE_MANAGER_ROLE, _adaptorRoles.gasServiceManager);
+        _grantRole(TARGET_MANAGER_ROLE, _adaptorRoles.targetManager);
 
         childBridge = IChildERC20Bridge(_childBridge);
         rootChainId = _rootChainId;

--- a/src/root/RootAxelarBridgeAdaptor.sol
+++ b/src/root/RootAxelarBridgeAdaptor.sol
@@ -54,24 +54,23 @@ contract RootAxelarBridgeAdaptor is
 
     /**
      * @notice Initialization function for RootAxelarBridgeAdaptor.
-     * @param _rootAxelarAdapterRoles Struct containing addresses of roles.
+     * @param _adaptorRoles Struct containing addresses of roles.
      * @param _rootBridge Address of root bridge contract.
      * @param _childChainId Axelar's ID for the child chain.
      * @param _childBridgeAdaptor Address of the bridge adaptor on the child chain.
      * @param _gasService Address of Axelar Gas Service contract.
      */
     function initialize(
-        InitializationRoles memory _rootAxelarAdapterRoles,
+        InitializationRoles memory _adaptorRoles,
         address _rootBridge,
         string memory _childChainId,
         string memory _childBridgeAdaptor,
         address _gasService
     ) public initializer {
         if (
-            _rootBridge == address(0) || _gasService == address(0) || _rootAxelarAdapterRoles.defaultAdmin == address(0)
-                || _rootAxelarAdapterRoles.bridgeManager == address(0)
-                || _rootAxelarAdapterRoles.gasServiceManager == address(0)
-                || _rootAxelarAdapterRoles.targetManager == address(0)
+            _rootBridge == address(0) || _gasService == address(0) || _adaptorRoles.defaultAdmin == address(0)
+                || _adaptorRoles.bridgeManager == address(0) || _adaptorRoles.gasServiceManager == address(0)
+                || _adaptorRoles.targetManager == address(0)
         ) {
             revert ZeroAddresses();
         }
@@ -86,10 +85,10 @@ contract RootAxelarBridgeAdaptor is
 
         __AccessControl_init();
 
-        _grantRole(DEFAULT_ADMIN_ROLE, _rootAxelarAdapterRoles.defaultAdmin);
-        _grantRole(BRIDGE_MANAGER_ROLE, _rootAxelarAdapterRoles.bridgeManager);
-        _grantRole(GAS_SERVICE_MANAGER_ROLE, _rootAxelarAdapterRoles.gasServiceManager);
-        _grantRole(TARGET_MANAGER_ROLE, _rootAxelarAdapterRoles.targetManager);
+        _grantRole(DEFAULT_ADMIN_ROLE, _adaptorRoles.defaultAdmin);
+        _grantRole(BRIDGE_MANAGER_ROLE, _adaptorRoles.bridgeManager);
+        _grantRole(GAS_SERVICE_MANAGER_ROLE, _adaptorRoles.gasServiceManager);
+        _grantRole(TARGET_MANAGER_ROLE, _adaptorRoles.targetManager);
 
         rootBridge = IRootERC20Bridge(_rootBridge);
         childChainId = _childChainId;


### PR DESCRIPTION
fixes: Rename the _roles input variable of the ChildAxelarBridgeAdaptor and RootAxelarBridgeAdaptor contracts in order to avoid variable name shadowing from the AccessControlUpgradeable dependency.