### PR TITLE
Audit: Disable call to executeWithToken on adaptors

### DIFF
--- a/src/child/ChildAxelarBridgeAdaptor.sol
+++ b/src/child/ChildAxelarBridgeAdaptor.sol
@@ -197,6 +197,19 @@ contract ChildAxelarBridgeAdaptor is
         childBridge.onMessageReceive(_payload);
     }
 
+    /**
+     * @inheritdoc AxelarExecutable
+     * @dev This function is called by the parent `AxelarExecutable` contract's `executeWithToken()` function.
+     *      However, this function is not required for the bridge, and thus reverts with an `UnsupportedOperation` error.
+     */
+    function _executeWithToken(string calldata, string calldata, bytes calldata, string calldata, uint256)
+        internal
+        pure
+        override
+    {
+        revert UnsupportedOperation();
+    }
+
     // slither-disable-next-line unused-state,naming-convention
     uint256[50] private __gapChildAxelarBridgeAdaptor;
 }

--- a/src/interfaces/child/IChildAxelarBridgeAdaptor.sol
+++ b/src/interfaces/child/IChildAxelarBridgeAdaptor.sol
@@ -71,6 +71,8 @@ interface IChildAxelarBridgeAdaptorErrors {
     error InvalidSourceChain();
     /// @notice Error when the source chain's message sender is not a recognised address.
     error InvalidSourceAddress();
+    /// @notice Error when a function that isn't supported by the adaptor is called.
+    error UnsupportedOperation();
 }
 
 /**

--- a/src/interfaces/root/IRootAxelarBridgeAdaptor.sol
+++ b/src/interfaces/root/IRootAxelarBridgeAdaptor.sol
@@ -75,6 +75,8 @@ interface IRootAxelarBridgeAdaptorErrors {
     error InvalidSourceAddress();
     /// @notice Error when a message received has invalid source chain.
     error InvalidSourceChain();
+    /// @notice Error when a function that isn't supported by the adaptor is called.
+    error UnsupportedOperation();
 }
 
 /**

--- a/src/root/RootAxelarBridgeAdaptor.sol
+++ b/src/root/RootAxelarBridgeAdaptor.sol
@@ -198,6 +198,19 @@ contract RootAxelarBridgeAdaptor is
         rootBridge.onMessageReceive(_payload);
     }
 
+    /**
+     * @inheritdoc AxelarExecutable
+     * @dev This function is called by the parent `AxelarExecutable` contract's `executeWithToken()` function.
+     *      However, this function is not required for the bridge, and thus reverts with an `UnsupportedOperation` error.
+     */
+    function _executeWithToken(string calldata, string calldata, bytes calldata, string calldata, uint256)
+        internal
+        pure
+        override
+    {
+        revert UnsupportedOperation();
+    }
+
     // slither-disable-next-line unused-state,naming-convention
     uint256[50] private __gapRootAxelarBridgeAdaptor;
 }

--- a/test/mocks/child/MockChildAxelarGateway.sol
+++ b/test/mocks/child/MockChildAxelarGateway.sol
@@ -6,5 +6,13 @@ contract MockChildAxelarGateway {
         return true;
     }
 
+    function validateContractCallAndMint(bytes32, string calldata, string calldata, bytes32, string calldata, uint256)
+        external
+        pure
+        returns (bool)
+    {
+        return true;
+    }
+
     function callContract(string memory childChain, string memory childBridgeAdaptor, bytes memory payload) external {}
 }

--- a/test/mocks/root/MockAxelarGateway.sol
+++ b/test/mocks/root/MockAxelarGateway.sol
@@ -8,4 +8,12 @@ contract MockAxelarGateway {
     function validateContractCall(bytes32, string calldata, string calldata, bytes32) external pure returns (bool) {
         return true;
     }
+
+    function validateContractCallAndMint(bytes32, string calldata, string calldata, bytes32, string calldata, uint256)
+        external
+        pure
+        returns (bool)
+    {
+        return true;
+    }
 }

--- a/test/unit/child/ChildAxelarBridgeAdaptor.t.sol
+++ b/test/unit/child/ChildAxelarBridgeAdaptor.t.sol
@@ -489,4 +489,19 @@ contract ChildAxelarBridgeAdaptorUnitTest is Test, IChildAxelarBridgeAdaptorErro
         axelarAdaptor.updateGasService(address(0));
         vm.stopPrank();
     }
+
+    /**
+     * UNSUPPORTED OPERATION
+     */
+
+    /// Check that executeWithToken function in AxelarExecutable cannot be called
+    function test_RevertIf_executeWithTokenCalled() public {
+        bytes32 commandId = bytes32("testCommandId");
+        bytes memory payload = abi.encodePacked("payload");
+        string memory tokenSymbol = "TST";
+        uint256 amount = 100;
+
+        vm.expectRevert(UnsupportedOperation.selector);
+        axelarAdaptor.executeWithToken(commandId, ROOT_CHAIN_NAME, ROOT_BRIDGE_ADAPTOR, payload, tokenSymbol, amount);
+    }
 }

--- a/test/unit/root/RootAxelarBridgeAdaptor.t.sol
+++ b/test/unit/root/RootAxelarBridgeAdaptor.t.sol
@@ -450,4 +450,21 @@ contract RootAxelarBridgeAdaptorTest is Test, IRootAxelarBridgeAdaptorEvents, IR
         vm.expectRevert(ZeroAddresses.selector);
         axelarAdaptor.updateGasService(address(0));
     }
+
+    /**
+     * UNSUPPORTED OPERATION
+     */
+
+    /// Check that executeWithToken function in AxelarExecutable cannot be called
+    function test_RevertIf_executeWithTokenCalled() public {
+        bytes32 commandId = bytes32("testCommandId");
+        bytes memory payload = abi.encodePacked("payload");
+        string memory tokenSymbol = "TST";
+        uint256 amount = 100;
+
+        vm.expectRevert(UnsupportedOperation.selector);
+        axelarAdaptor.executeWithToken(
+            commandId, CHILD_CHAIN_NAME, CHILD_BRIDGE_ADAPTOR_STRING, payload, tokenSymbol, amount
+        );
+    }
 }


### PR DESCRIPTION
This PR addresses [SMR-2127](https://immutable.atlassian.net/browse/SMR-2127?atlOrigin=eyJpIjoiMWQ4Mzc4NzQ1NjQ5NDgwYmJiOTU1N2Y1ZmVjZTkzMmQiLCJwIjoiaiJ9) raised in the ToB audit

The PR overrides the `_executeWithToken` function from the `AxelarExecutable` contract so that it explicitly reverts, instead of relying on the `validateContractCallAndMint` function of the `AxelarGateway` reverting if users call the `executeWithToken` function.

[SMR-2127]: https://immutable.atlassian.net/browse/SMR-2127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ