### PR TITLE
Fix CI issue with slither-action

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: crytic/slither-action@v0.3.0
+      - uses: crytic/slither-action@v0.3.1
         with:
           fail-on: high
           slither-args: --filter-paths "./lib|./test"


### PR DESCRIPTION
Currently, all CI builds fail because of an issue with how slither-action installs Foundry. This PR fixes this by upgrading to the latest version of Slither-action that addresses this issue. This PR addresses [SMR-2378](https://immutable.atlassian.net/browse/SMR-2378?atlOrigin=eyJpIjoiNzAwMmVjOWQyMzA5NGQxMmFmOTBmMTcwYTdlOTJkZjkiLCJwIjoiaiJ9).

[SMR-2378]: https://immutable.atlassian.net/browse/SMR-2378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ