### PR TITLE
SRE-2252: Switch to fine-grained token with single scope

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,7 +5,7 @@ on:
 
 env:
   FOUNDRY_PROFILE: ci
-  GITHUB_TOKEN: ${{ secrets.PLATFORM_SA_GITHUB_TOKEN }}
+  GITHUB_TOKEN: ${{ secrets.ZKEVM_BRIDGE_CONTRACTS_GITHUB_TOKEN }}
 
 jobs:
   check:


### PR DESCRIPTION
Required for coverage report, previous token no longer valid

Test failure is expected and is being fixed in another PR