### PR TITLE
Update flow rate params in doc

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly-e4ab9f460e92586fc4d4f6c9e00d8cda0c2dabf0
+          version: nightly
 
       - name: Run install
         uses: borales/actions-yarn@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly-e4ab9f460e92586fc4d4f6c9e00d8cda0c2dabf0
+          version: nightly
 
       - name: Run Forge build
         run: |

--- a/README.md
+++ b/README.md
@@ -170,22 +170,25 @@ Below are the [flow rate](https://github.com/immutable/zkevm-bridge-contracts/bl
 
 **Mainnet**
 
-| Token                                                                                               | Units | Capacity   | Refill Rate | Large Transfer Threshold | 
-|-----------------------------------------------------------------------------------------------------|:------|------------|-------------|--------------------------|
-| ETH                                                                                                 | 10^18 | 29.13      | 0.0081      | 23.18                    |
-| [USDC](https://etherscan.io/token/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48)                       | 10^6  | 93,000     | 25.83       | 74,000                   |
-| [USDT](https://etherscan.io/token/0xdAC17F958D2ee523a2206206994597C13D831ec7)                       | 10^6  | 93,027     | 25.84       | 74,022                   |
-| [IMX](https://etherscan.io/token/0xf57e7e7c23978c3caec3c3548e3d615c346e79ff)                        | 10^18 | 35,755     | 9.93        | 28,450                   |
-| [wBTC](https://etherscan.io/token/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599)                       | 10^8  | 1.49       | 0.0004      | 1.18                     |
-| [Gods Unchained (GODS)](https://etherscan.io/address/0xccC8cb5229B0ac8069C51fd58367Fd1e622aFD97)    | 10^18 | 296,556    | 82.37       | 235,969.39               |
-| [Guild of Guardians (GOG)](https://etherscan.io/address/0x9AB7bb7FdC60f4357ECFef43986818A2A3569c62) | 10^18 | 670,995.67 | 186.38      | 533,910.53               |
+| Token                                                                                               | Units | Capacity | Refill Rate | Large Transfer Threshold | 
+|-----------------------------------------------------------------------------------------------------|:------|----------|-------------|--------------------------|
+| ETH                                                                                                 | 10^18 | 57.98    | 0.0081      | 23.07                    |
+| [USDC](https://etherscan.io/token/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48)                       | 10^6  | 186,000  | 25.83       | 74,000                   |
+| [USDT](https://etherscan.io/token/0xdAC17F958D2ee523a2206206994597C13D831ec7)                       | 10^6  | 186,000  | 25.83       | 74,000                   |
+| [IMX](https://etherscan.io/token/0xf57e7e7c23978c3caec3c3548e3d615c346e79ff)                        | 10^18 | 89,855   | 12.48       | 35,748                   |
+| [wBTC](https://etherscan.io/token/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599)                       | 10^8  | 2.92     | 0.0004      | 1.16                     |
+| [Gods Unchained (GODS)](https://etherscan.io/address/0xccC8cb5229B0ac8069C51fd58367Fd1e622aFD97)    | 10^18 | 832,960  | 115.69      | 331,392                  |
+| [Guild of Guardians (GOG)](https://etherscan.io/address/0x9AB7bb7FdC60f4357ECFef43986818A2A3569c62) | 10^18 | 737,802  | 102.47      | 293,534                  |
 
 **Testnet**
 
-| Token                                                                                  | Units | Capacity | Refill Rate | Large Transfer Threshold | 
-|----------------------------------------------------------------------------------------|:------|----------|-------------|--------------------------|
-| ETH                                                                                    | 10^18 | 10.08    | 0.0028      | 5.04                     |
-| [IMX](https://sepolia.etherscan.io/address/0xe2629e08f4125d14e446660028bd98ee60ee69ff) | 10^18 | 68,976   | 19.16       | 34,488                   |
+| Token                                                                                                       | Units | Capacity | Refill Rate | Large Transfer Threshold | 
+|-------------------------------------------------------------------------------------------------------------|:------|----------|-------------|--------------------------|
+| ETH                                                                                                         | 10^18 | 10.08    | 0.0028      | 5.04                     |
+| [USDC](https://sepolia.etherscan.io/address/0x40b87d235A5B010a20A241F15797C9debf1ecd01)                     | 10^6  | 186,000  | 25.83       | 74,000                   |
+| [IMX](https://sepolia.etherscan.io/address/0xe2629e08f4125d14e446660028bd98ee60ee69ff)                      | 10^18 | 68,976   | 19.16       | 34,488                   |
+| [Guild of Guardians (GOG)](https://sepolia.etherscan.io/address/0xFe9dF9eBe5FBd94B00247613B6Cf7629891954E2) | 10^18 | 737,802  | 102.47      | 293,534                  |
+| [NetMarble MarbleX (MBX)](https://sepolia.etherscan.io/address/0x6328ac88ba8d466a0f551fc7c42c61d1ac7f92ab)  | 10^18 | 213,793  | 29.69       | 85,057                   |
 
 ## Manual Bridging Guide
 The process to manually bridge funds from Ethereum to Immutable zkEVM by directly interacting with the bridge contracts is documented [here](docs/manual-bridging.md). However, the recommended method for bridging to and from the Immutable zkEVM is to use the [Immutable Toolkit](https://toolkit.immutable.com/bridge/) user interface.


### PR DESCRIPTION
The flow rate parameters documented in the README are currently out of date following [recent updates](https://immutable.atlassian.net/wiki/spaces/~712020640315cc7a594fb28a6b452c5a8ef6a3/pages/2516123663/Updating+Flow+Rate+Parameters+-+30-04-2024) on the mainnet and testnet bridge instances. This PR updates the documentation to reflect the latest configuration.